### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
+def index
+  @items = Item.all.order("created_at DESC")
+
+end
 
   def new
     @item = Item.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
-def index
-  @items = Item.all.order("created_at DESC")
-
-end
+  def index
+    @items = Item.all.order('created_at DESC')
+  end
 
   def new
     @item = Item.new
@@ -19,6 +18,7 @@ end
   end
 
   private
+
   def item_params
     params.require(:item).permit(:image, :product_name, :product_name_explanation, :category_id, :condition_id, :shipping_charges_id, :prefectures_id, :says_to_ship_id, :price).merge(user_id: current_user.id)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,13 +6,13 @@ class Item < ApplicationRecord
     validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
   end
   with_options numericality: { other_than: 1 } do
-  validates :category_id
-  validates :condition_id
-  validates :shipping_charges_id
-  validates :prefectures_id
-  validates :says_to_ship_id
+    validates :category_id
+    validates :condition_id
+    validates :shipping_charges_id
+    validates :prefectures_id
+    validates :says_to_ship_id
   end
-  
+
   has_one_attached :image
   belongs_to :user
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,9 +128,10 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
+     <% @items.each do |item| %>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,39 +142,40 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.product_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_charges.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
+          <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
+      <%# <li class='list'> %>
+        <%# <%= link_to '#' do %> 
+        <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %> 
+        <%# <div class='item-info'> %>
+          <%# <h3 class='item-name'> %>
+            <%# 商品を出品してね！
+          </h3> %>
+          <%# <div class='item-price'> %>
+            <%# <span>99999999円<br>(税込み)</span> %>
+            <%# <div class='star-btn'> %>
+              <%# <%= image_tag "star.png", class:"star-icon" %> 
+              <%# <span class='star-count'>0</span> %>
+            <%# </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+        </div> %>
+        <%# <% end %> 
+      <%# </li> %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,9 +126,9 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
+        <% @items.each do |item| %>
       <li class='list'>
-     <% @items.each do |item| %>
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
@@ -153,31 +153,8 @@
           </div>
         </div>
           <% end %>
-        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%# <li class='list'> %>
-        <%# <%= link_to '#' do %> 
-        <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %> 
-        <%# <div class='item-info'> %>
-          <%# <h3 class='item-name'> %>
-            <%# 商品を出品してね！
-          </h3> %>
-          <%# <div class='item-price'> %>
-            <%# <span>99999999円<br>(税込み)</span> %>
-            <%# <div class='star-btn'> %>
-              <%# <%= image_tag "star.png", class:"star-icon" %> 
-              <%# <span class='star-count'>0</span> %>
-            <%# </div>
-          </div>
-        </div> %>
-        <%# <% end %> 
-      <%# </li> %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+        <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,8 +126,9 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      
-        <% @items.each do |item| %>
+      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if Item.take%>
+      <%  @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -154,7 +155,32 @@
         </div>
           <% end %>
       </li>
+         <% end %>
+      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
+      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+      <% else  %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
         <% end %>
+      </li>
+      <%end%>
+      <%# //商品がある場合は表示されないようにしましょう %>
+      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create]
+  resources :items, only: [:index, :new, :create]
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Item, type: :model do
       end
       it '価格が10,000,000以上だと登録できない' do
         @item = FactoryBot.build(:item)
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include 'Price must be less than or equal to 9999999'
       end


### PR DESCRIPTION
#What
商品一覧表示機能作成

#Why
商品一覧表示機能の実装の為

・出品した商品の一覧表示ができていること
・「画像/価格/商品名」の3つの情報について表示できていること
・ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/ace8d1dbd5a24473a3976e8cba26bff0
・上から、出品された日時が新しい順に表示されること
https://gyazo.com/ebb131bb4cd5875e5bb8a7c0bfdc4172